### PR TITLE
Adjust PkgCopier arguments

### DIFF
--- a/RingCentralMeetings/RingCentralMeetings.pkg.recipe
+++ b/RingCentralMeetings/RingCentralMeetings.pkg.recipe
@@ -76,8 +76,6 @@
 				<string>%pathname%</string>
 				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/RingCentralMeetings-%version%.pkg</string>
-				<key>overwrite</key>
-				<false/>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCopier</string>


### PR DESCRIPTION
`overwrite` is not a valid input variable for [PkgCopier](https://github.com/autopkg/autopkg/wiki/Processor-PkgCopier), and has no effect here.