### PR TITLE
Remove unused BUNDLE_ID input var

### DIFF
--- a/Caffeine/Caffeine.pkg.recipe
+++ b/Caffeine/Caffeine.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.peetinc.pkg.Caffeine</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.intelliscapesolutions.caffeine</string>
 		<key>NAME</key>
 		<string>Caffeine</string>
 	</dict>

--- a/LogMeInClient/LogMeInClient.pkg.recipe
+++ b/LogMeInClient/LogMeInClient.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.peetinc.pkg.LogMeInClient</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.logmein.ignition</string>
 		<key>NAME</key>
 		<string>LogMeIn Client</string>
 	</dict>

--- a/MacUpdater/MacUpdater.pkg.recipe
+++ b/MacUpdater/MacUpdater.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.peetinc.pkg.MacUpdater</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.corecode.MacUpdater</string>
 		<key>NAME</key>
 		<string>MacUpdater</string>
 	</dict>

--- a/OndrejFlorian/VipRiser.pkg.recipe
+++ b/OndrejFlorian/VipRiser.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.peetinc.pkg.VipRiser</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.onflapp.VipRiser</string>
 		<key>NAME</key>
 		<string>VipRiser</string>
 	</dict>

--- a/Rectangle/Rectangle.pkg.recipe
+++ b/Rectangle/Rectangle.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.peetinc.pkg.Rectangle</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.knollsoft.Rectangle</string>
 		<key>NAME</key>
 		<string>Rectangle</string>
 	</dict>

--- a/RingCentralMeetings/RingCentralMeetings.pkg.recipe
+++ b/RingCentralMeetings/RingCentralMeetings.pkg.recipe
@@ -11,8 +11,6 @@
 	<string>com.github.peetinc.pkg.RingCentralMeetings</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>us.zoom.ringcentral</string>
 		<key>NAME</key>
 		<string>RingCentralMeetings</string>
 	</dict>
@@ -72,10 +70,10 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
-				<key>source_pkg</key>
-				<string>%pathname%</string>
 				<key>pkg_path</key>
 				<string>%RECIPE_CACHE_DIR%/downloads/RingCentralMeetings-%version%.pkg</string>
+				<key>source_pkg</key>
+				<string>%pathname%</string>
 			</dict>
 			<key>Processor</key>
 			<string>PkgCopier</string>

--- a/SyncroMSP/SyncroAgent.pkg.recipe
+++ b/SyncroMSP/SyncroAgent.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.peetinc.pkg.SyncroAgent</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.syncromsp.SyncroAgent</string>
 		<key>NAME</key>
 		<string>SyncroAgent</string>
 	</dict>
@@ -25,7 +23,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>app_path</key>
-				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/SyncroAgent.app</string>	
+				<string>%RECIPE_CACHE_DIR%/%NAME%/Applications/SyncroAgent.app</string>
 			</dict>
 			<key>Processor</key>
 			<string>AppPkgCreator</string>

--- a/Unlox/Unlox.pkg.recipe
+++ b/Unlox/Unlox.pkg.recipe
@@ -10,8 +10,6 @@
 	<string>com.github.peetinc.pkg.Unlox</string>
 	<key>Input</key>
 	<dict>
-		<key>BUNDLE_ID</key>
-		<string>com.kanecheshire.macID-macOS</string>
 		<key>NAME</key>
 		<string>Unlox</string>
 	</dict>


### PR DESCRIPTION
This pull request removes unused instances of `BUNDLE_ID` from recipe input variables, which will help reduce confusion by new AutoPkg users and simplify overrides created from this point on.

Making `BUNDLE_ID` available as an input variable is a common practice in AutoPkg recipes that use the [PkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-PkgCreator) processor ([example](https://github.com/autopkg/homebysix-recipes/blob/4fec9244a3af0f9b7c8f61f35a5cd7f4622fb162/soma-zone/LaunchControl.pkg.recipe#L40-L41)). It's likely that these recipes transitioned from PkgCreator to the more streamlined [AppPkgCreator](https://github.com/autopkg/autopkg/wiki/Processor-AppPkgCreator) processor some time ago, but the now-unused input variable for `BUNDLE_ID` was never removed.

Because an automated script helped make this change, modified recipes have also been converted to align with the output of `plutil -convert xml` and Python's `plistlib`. This results in reordering of dictionary keys and reindentation using tabs, neither of which will affect the recipe's function.

Recipe run output is included below for all changed recipes (excluding jss and install recipe types). Any run failures are very likely to be unrelated to this change.

## ✅ Caffeine/Caffeine.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/peetinc-recipes/Caffeine/Caffeine.pkg.recipe
Processing repos/peetinc-recipes/Caffeine/Caffeine.pkg.recipe...
GitHubReleasesInfoProvider
{'Input': {'github_repo': 'IntelliScape/caffeine'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: Selected asset 'Caffeine.dmg' from release '1.1.3'
{'Output': {'release_notes': 'New:\r\n'
                             '- Support for macOS Mojave, Catalina (including '
                             'Dark Mode)\r\n'
                             '- Release is now notarized by Apple.\r\n'
                             '- Hardened Runtime enabled for security.\r\n'
                             '- Updated menu bar icons to improve appearance '
                             'on Retina displays.\r\n'
                             '- Improved experience when prompting for '
                             'accessibility permissions.\r\n'
                             '- Help & Feedback area to enhance user '
                             'support.\r\n'
                             '\r\n'
                             'Fixed:\r\n'
                             '- Icon occasionally remains highlighted after '
                             'closing menu on macOS Sierra and later.',
            'url': 'https://github.com/IntelliScape/caffeine/releases/download/1.1.3/Caffeine.dmg',
            'version': '1.1.3'}}
URLDownloader
{'Input': {'url': 'https://github.com/IntelliScape/caffeine/releases/download/1.1.3/Caffeine.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Caffeine/downloads/Caffeine.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Caffeine/downloads/Caffeine.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Caffeine/downloads/Caffeine.dmg/Caffeine.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.intelliscapesolutions.caffeine" and '
                          '(certificate leaf[field.1.2.840.113635.100.6.1.9] '
                          '/* exists */ or certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'YD6LEYT6WZ)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Caffeine/downloads/Caffeine.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.aI9G5T/Caffeine.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.aI9G5T/Caffeine.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.aI9G5T/Caffeine.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '1.1.3'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Caffeine/downloads/Caffeine.dmg
AppPkgCreator: Using path '/private/tmp/dmg.efqUe5/Caffeine.app' matched from globbed '/private/tmp/dmg.efqUe5/*.app'.
AppPkgCreator: BundleID: com.intelliscapesolutions.caffeine
AppPkgCreator: Copied /private/tmp/dmg.efqUe5/Caffeine.app to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Caffeine/payload/Applications/Caffeine.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.intelliscapesolutions.caffeine',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Caffeine/Caffeine-1.1.3.pkg',
                                                        'version': '1.1.3'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '1.1.3'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Caffeine/receipts/Caffeine.pkg-receipt-20210213-234656.plist

The following packages were built:
    Identifier                          Version  Pkg Path                                                                                 
    ----------                          -------  --------                                                                                 
    com.intelliscapesolutions.caffeine  1.1.3    ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Caffeine/Caffeine-1.1.3.pkg  
```

## ✅ LogMeInClient/LogMeInClient.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/peetinc-recipes/LogMeInClient/LogMeInClient.pkg.recipe
Processing repos/peetinc-recipes/LogMeInClient/LogMeInClient.pkg.recipe...
URLDownloader
{'Input': {'filename': 'LogMeIn Client.dmg',
           'url': 'https://secure.logmein.com/LogMeInClientMac.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.LogMeInClient/downloads/LogMeIn Client.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.LogMeInClient/downloads/LogMeIn '
                        'Client.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.LogMeInClient/downloads/LogMeIn '
                         'Client.dmg/LogMeIn Client.app',
           'requirement': 'anchor apple generic and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or anchor apple generic) and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'GFNFVT632V and identifier "com.logmein.ignition"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.LogMeInClient/downloads/LogMeIn Client.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.IRLpX3/LogMeIn Client.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.IRLpX3/LogMeIn Client.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.IRLpX3/LogMeIn Client.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.LogMeInClient/downloads/LogMeIn '
                               'Client.dmg/LogMeIn '
                               'Client.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.LogMeInClient/downloads/LogMeIn Client.dmg
Versioner: Found version 4.1.7632 in file /private/tmp/dmg.L3CRbY/LogMeIn Client.app/Contents/Info.plist
{'Output': {'version': '4.1.7632'}}
AppPkgCreator
{'Input': {'version': '4.1.7632'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.LogMeInClient/downloads/LogMeIn Client.dmg
AppPkgCreator: Using path '/private/tmp/dmg.ugF5s2/LogMeIn Client.app' matched from globbed '/private/tmp/dmg.ugF5s2/*.app'.
AppPkgCreator: BundleID: com.logmein.ignition
AppPkgCreator: Copied /private/tmp/dmg.ugF5s2/LogMeIn Client.app to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.LogMeInClient/payload/Applications/LogMeIn Client.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.logmein.ignition',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.LogMeInClient/LogMeIn '
                                                                    'Client-4.1.7632.pkg',
                                                        'version': '4.1.7632'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '4.1.7632'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.LogMeInClient/receipts/LogMeInClient.pkg-receipt-20210213-234708.plist

The following packages were built:
    Identifier            Version   Pkg Path                                                                                               
    ----------            -------   --------                                                                                               
    com.logmein.ignition  4.1.7632  ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.LogMeInClient/LogMeIn Client-4.1.7632.pkg  
```

## ❌ MacUpdater/MacUpdater.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/peetinc-recipes/MacUpdater/MacUpdater.pkg.recipe
Processing repos/peetinc-recipes/MacUpdater/MacUpdater.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://www.corecode.io/macupdater/macupdater.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 8942
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.5.10
SparkleUpdateInfoProvider: Found URL https://www.corecode.io/downloads/macupdater_1.5.10.dmg
{'Output': {'url': 'https://www.corecode.io/downloads/macupdater_1.5.10.dmg',
            'version': '1.5.10'}}
URLDownloader
{'Input': {'filename': 'MacUpdater-1.5.10.dmg',
           'url': 'https://www.corecode.io/downloads/macupdater_1.5.10.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.MacUpdater/downloads/MacUpdater-1.5.10.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.MacUpdater/downloads/MacUpdater-1.5.10.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
InstallFromDMG
{'Input': {'dmg_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.MacUpdater/downloads/MacUpdater-1.5.10.dmg',
           'download_changed': False,
           'items_to_copy': [{'destination_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.MacUpdater/MacUpdater',
                              'group': 'wheel',
                              'mode': '0755',
                              'source_item': 'MacUpdater.app',
                              'user': 'root'}]}}
InstallFromDMG: Skipping installation: no new download.
{'Output': {'install_result': 'SKIPPED'}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.MacUpdater/MacUpdater/MacUpdater.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.corecode.MacUpdater" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "9D78DG5ACV")'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.MacUpdater/receipts/MacUpdater.pkg-receipt-20210213-234711.plist

The following recipes failed:
    repos/peetinc-recipes/MacUpdater/MacUpdater.pkg.recipe
        Error in com.github.peetinc.pkg.MacUpdater: Processor: CodeSignatureVerifier: Error: Error processing path '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.MacUpdater/MacUpdater/MacUpdater.app' with glob. 

Nothing downloaded, packaged or imported.
```

## ✅ OndrejFlorian/VipRiser.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/peetinc-recipes/OndrejFlorian/VipRiser.pkg.recipe
Processing repos/peetinc-recipes/OndrejFlorian/VipRiser.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://onflapp.github.io/blog/releases/vipriser/appcast.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 3.7
SparkleUpdateInfoProvider: Found URL https://onflapp.github.io/blog/releases/vipriser/VipRiser.zip
{'Output': {'url': 'https://onflapp.github.io/blog/releases/vipriser/VipRiser.zip',
            'version': '3.7'}}
URLDownloader
{'Input': {'filename': 'VipRiser-3.7.zip',
           'url': 'https://onflapp.github.io/blog/releases/vipriser/VipRiser.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.VipRiser/downloads/VipRiser-3.7.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.VipRiser/downloads/VipRiser-3.7.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.VipRiser/downloads/VipRiser-3.7.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.VipRiser/VipRiser',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename VipRiser-3.7.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.VipRiser/downloads/VipRiser-3.7.zip to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.VipRiser/VipRiser
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.VipRiser/VipRiser/VipRiser.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.onflapp.VipRiser" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = J2F8FP4PYH)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.VipRiser/VipRiser/VipRiser.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.VipRiser/VipRiser/VipRiser.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.VipRiser/VipRiser/VipRiser.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.VipRiser/VipRiser/VipRiser.app',
           'version': '3.7'}}
AppPkgCreator: BundleID: com.onflapp.VipRiser
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.VipRiser/VipRiser/VipRiser.app to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.VipRiser/payload/Applications/VipRiser.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.onflapp.VipRiser',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.VipRiser/VipRiser-3.7.pkg',
                                                        'version': '3.7'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '3.7'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.VipRiser/receipts/VipRiser.pkg-receipt-20210213-234716.plist

The following packages were built:
    Identifier            Version  Pkg Path                                                                               
    ----------            -------  --------                                                                               
    com.onflapp.VipRiser  3.7      ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.VipRiser/VipRiser-3.7.pkg  
```

## ✅ Rectangle/Rectangle.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/peetinc-recipes/Rectangle/Rectangle.pkg.recipe
Processing repos/peetinc-recipes/Rectangle/Rectangle.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://rectangleapp.com/downloads/updates.xml'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 48
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 0.43
SparkleUpdateInfoProvider: Found URL https://github.com/rxhanson/Rectangle/releases/download/v0.43/Rectangle0.43.dmg
{'Output': {'url': 'https://github.com/rxhanson/Rectangle/releases/download/v0.43/Rectangle0.43.dmg',
            'version': '0.43'}}
URLDownloader
{'Input': {'filename': 'Rectangle-0.43.dmg',
           'url': 'https://github.com/rxhanson/Rectangle/releases/download/v0.43/Rectangle0.43.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Rectangle/downloads/Rectangle-0.43.dmg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Rectangle/downloads/Rectangle-0.43.dmg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Rectangle/downloads/Rectangle-0.43.dmg/Rectangle.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.knollsoft.Rectangle" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = XSYZ3E4B7D)'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Rectangle/downloads/Rectangle-0.43.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.2cuKWT/Rectangle.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.2cuKWT/Rectangle.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.2cuKWT/Rectangle.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '0.43'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Rectangle/downloads/Rectangle-0.43.dmg
AppPkgCreator: Using path '/private/tmp/dmg.spPNST/Rectangle.app' matched from globbed '/private/tmp/dmg.spPNST/*.app'.
AppPkgCreator: BundleID: com.knollsoft.Rectangle
AppPkgCreator: Copied /private/tmp/dmg.spPNST/Rectangle.app to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Rectangle/payload/Applications/Rectangle.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.knollsoft.Rectangle',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Rectangle/Rectangle-0.43.pkg',
                                                        'version': '0.43'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '0.43'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Rectangle/receipts/Rectangle.pkg-receipt-20210213-234729.plist

The following packages were built:
    Identifier               Version  Pkg Path                                                                                  
    ----------               -------  --------                                                                                  
    com.knollsoft.Rectangle  0.43     ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Rectangle/Rectangle-0.43.pkg  
```

## ✅ RingCentralMeetings/RingCentralMeetings.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/peetinc-recipes/RingCentralMeetings/RingCentralMeetings.pkg.recipe
Processing repos/peetinc-recipes/RingCentralMeetings/RingCentralMeetings.pkg.recipe...
URLTextSearcher
{'Input': {'re_pattern': '(dn\\.ringcentral\\.com\\/data\\/web\\/download\\/RCMeetings\\/[\\d]+\\/RCMeetingsClientSetup\\.pkg)',
           'result_output_var_name': 'download_path',
           'url': 'https://www.ringcentral.com/office/features/online-meetings/video-conferencing.html'}}
URLTextSearcher: Found matching text (download_path): dn.ringcentral.com/data/web/download/RCMeetings/1210/RCMeetingsClientSetup.pkg
{'Output': {'download_path': 'dn.ringcentral.com/data/web/download/RCMeetings/1210/RCMeetingsClientSetup.pkg'}}
URLDownloader
{'Input': {'url': 'http://dn.ringcentral.com/data/web/download/RCMeetings/1210/RCMeetingsClientSetup.pkg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/downloads/RCMeetingsClientSetup.pkg
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/downloads/RCMeetingsClientSetup.pkg'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: RingCentral, '
                                        'Inc. (M932RC5J66)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/downloads/RCMeetingsClientSetup.pkg'}}
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "RCMeetingsClientSetup.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2020-06-19 06:35:58 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: RingCentral, Inc. (M932RC5J66)
CodeSignatureVerifier:        Expires: 2023-08-17 12:22:11 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            95 A7 2F C4 4F 3C BF 2C CB 8E 71 5D 94 0F EF 24 6A 00 EB 52 5A 99 
CodeSignatureVerifier:            45 4A 26 9F D7 EA A9 30 1C 43
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03 
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
PkgRootCreator
{'Input': {'pkgdirs': {'Applications': '0775'},
           'pkgroot': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/RingCentralMeetings'}}
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/RingCentralMeetings
PkgRootCreator: Creating Applications
PkgRootCreator: Created ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/RingCentralMeetings/Applications
{'Output': {}}
FlatPkgUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/expanded',
           'flat_pkg_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/downloads/RCMeetingsClientSetup.pkg'}}
FlatPkgUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/downloads/RCMeetingsClientSetup.pkg to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/expanded
{'Output': {}}
PkgPayloadUnpacker
{'Input': {'destination_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/RingCentralMeetings/Applications/',
           'pkg_payload_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/expanded/install.pkg/Payload'}}
PkgPayloadUnpacker: Unpacked ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/expanded/install.pkg/Payload to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/RingCentralMeetings/Applications/
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/RingCentralMeetings/Applications/RingCentral '
                               'Meetings.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: Found version 20.2.8534.0618 in file ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/RingCentralMeetings/Applications/RingCentral Meetings.app/Contents/Info.plist
{'Output': {'version': '20.2.8534.0618'}}
PkgCopier
{'Input': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/downloads/RingCentralMeetings-20.2.8534.0618.pkg',
           'source_pkg': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/downloads/RCMeetingsClientSetup.pkg'}}
PkgCopier: Copied ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/downloads/RCMeetingsClientSetup.pkg to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/downloads/RingCentralMeetings-20.2.8534.0618.pkg
{'Output': {'pkg_copier_summary_result': {'data': {'pkg_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/downloads/RingCentralMeetings-20.2.8534.0618.pkg'},
                                          'summary_text': 'The following '
                                                          'packages were '
                                                          'copied:'},
            'pkg_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/downloads/RingCentralMeetings-20.2.8534.0618.pkg'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/receipts/RingCentralMeetings.pkg-receipt-20210213-234731.plist

The following packages were copied:
    Pkg Path                                                                                                                          
    --------                                                                                                                          
    ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.RingCentralMeetings/downloads/RingCentralMeetings-20.2.8534.0618.pkg  
```

## ✅ SyncroMSP/SyncroAgent.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/peetinc-recipes/SyncroMSP/SyncroAgent.pkg.recipe
Processing repos/peetinc-recipes/SyncroMSP/SyncroAgent.pkg.recipe...
URLDownloader
{'Input': {'filename': 'SyncroAgent.zip',
           'url': 'https://production.kabutoservices.com/macos/SyncroAgent-Latest.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/downloads/SyncroAgent.zip
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/downloads/SyncroAgent.zip'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/downloads/SyncroAgent.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/SyncroAgent/Applications',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'zip' from filename SyncroAgent.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/downloads/SyncroAgent.zip to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/SyncroAgent/Applications
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/SyncroAgent/Applications/SyncroAgent.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.syncromsp.SyncroAgent" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = J48NK7YQ6B)'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/SyncroAgent/Applications/SyncroAgent.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/SyncroAgent/Applications/SyncroAgent.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/SyncroAgent/Applications/SyncroAgent.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/SyncroAgent/Applications/SyncroAgent.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleVersion'}}
Versioner: Found version 69 in file ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/SyncroAgent/Applications/SyncroAgent.app/Contents/Info.plist
{'Output': {'version': '69'}}
PlistReader
{'Input': {'info_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/SyncroAgent/Applications/SyncroAgent.app/Contents/Info.plist',
           'plist_keys': {'LSMinimumSystemVersion': 'min_os_vers'}}}
PlistReader: Reading: ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/SyncroAgent/Applications/SyncroAgent.app/Contents/Info.plist
PlistReader: Assigning value of '10.9' to output variable 'min_os_vers'
{'Output': {'plist_reader_output_variables': {'min_os_vers': '10.9'}}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/SyncroAgent/Applications/SyncroAgent.app',
           'version': '69'}}
AppPkgCreator: BundleID: com.syncromsp.SyncroAgent
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/SyncroAgent/Applications/SyncroAgent.app to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/payload/Applications/SyncroAgent.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.syncromsp.SyncroAgent',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/SyncroAgent-69.pkg',
                                                        'version': '69'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '69'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/receipts/SyncroAgent.pkg-receipt-20210213-234739.plist

The following packages were built:
    Identifier                 Version  Pkg Path                                                                                    
    ----------                 -------  --------                                                                                    
    com.syncromsp.SyncroAgent  69       ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.SyncroAgent/SyncroAgent-69.pkg  
```

## ❌ Unlox/Unlox.pkg.recipe

```
% /usr/local/bin/autopkg run -vvq repos/peetinc-recipes/Unlox/Unlox.pkg.recipe
Processing repos/peetinc-recipes/Unlox/Unlox.pkg.recipe...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://unlox.it/download/update.php'}}
SparkleUpdateInfoProvider: Version retrieved from appcast: 3.0.4.2
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 3.0.4 (2)
SparkleUpdateInfoProvider: Found URL https://unlox.it/download/
{'Output': {'url': 'https://unlox.it/download/', 'version': '3.0.4 (2)'}}
URLDownloader
{'Input': {'filename': 'Unlox-3.0.4 (2).tgz',
           'url': 'https://unlox.it/download/'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: File size returned by webserver matches that of the cached file: 10355116 bytes
URLDownloader: WARNING: Matching a download by filesize is a fallback mechanism that does not guarantee that a build is unchanged.
URLDownloader: Using existing ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Unlox/downloads/Unlox-3.0.4 (2).tgz
{'Output': {'pathname': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Unlox/downloads/Unlox-3.0.4 '
                        '(2).tgz'}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Unlox/downloads/Unlox-3.0.4 '
                           '(2).tgz',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Unlox/Unlox',
           'purge_destination': True}}
Unarchiver: Guessed archive format 'tar_gzip' from filename Unlox-3.0.4 (2).tgz
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Unlox/downloads/Unlox-3.0.4 (2).tgz to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Unlox/Unlox
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Unlox/Unlox/Unlox.app',
           'requirement': 'anchor apple generic and identifier '
                          '"com.kanecheshire.macID-macOS" and (certificate '
                          'leaf[field.1.2.840.113635.100.6.1.9] /* exists */ '
                          'or certificate 1[field.1.2.840.113635.100.6.2.6] /* '
                          'exists */ and certificate '
                          'leaf[field.1.2.840.113635.100.6.1.13] /* exists */ '
                          'and certificate leaf[subject.OU] = "9BCL7VAFF4")'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Unlox/Unlox/Unlox.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Unlox/Unlox/Unlox.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Unlox/Unlox/Unlox.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'app_path': '~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Unlox/Unlox/Unlox.app',
           'version': '3.0.4 (2)'}}
AppPkgCreator: BundleID: com.kanecheshire.macID-macOS
AppPkgCreator: Copied ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Unlox/Unlox/Unlox.app to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Unlox/payload/Applications/Unlox.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
Receipt written to ~/Library/AutoPkg/Cache/com.github.peetinc.pkg.Unlox/receipts/Unlox.pkg-receipt-20210213-234800.plist

The following recipes failed:
    repos/peetinc-recipes/Unlox/Unlox.pkg.recipe
        Error in com.github.peetinc.pkg.Unlox: Processor: AppPkgCreator: Error: Invalid package name

Nothing downloaded, packaged or imported.
```

