### PR TITLE
Update SplashtopStreamer.download.recipe

### DIFF
--- a/SplashtopStreamer/SplashtopStreamer.download.recipe
+++ b/SplashtopStreamer/SplashtopStreamer.download.recipe
@@ -42,7 +42,7 @@
 					<string>Apple Root CA</string>
 				</array>
 				<key>input_path</key>
-				<string>%pathname%/.Splashtop Streamer.pkg</string>
+				<string>%pathname%/Splashtop Streamer.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
@@ -53,7 +53,7 @@
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
 				<key>flat_pkg_path</key>
-				<string>%pathname%/.Splashtop Streamer.pkg</string>
+				<string>%pathname%/Splashtop Streamer.pkg</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>


### PR DESCRIPTION
Hi, @PeetMcK 

The Splashtop Streamer recipes are currently failing with the following error
```
Processor: CodeSignatureVerifier: Error: Error processing path '/private/tmp/dmg.llafIZ/.Splashtop Streamer.pkg' with glob.
```

This PR updates the path to the Splashtop Streamer.pkg

Output from a successful -v run 
```
autopkg run -v SplashtopStreamer.munki.recipe
Looking for com.github.peetinc.download.SplashtopStreamer...
Did not find com.github.peetinc.download.SplashtopStreamer in recipe map
Rebuilding recipe map with current working directories...
Looking for com.github.peetinc.download.SplashtopStreamer...
Found com.github.peetinc.download.SplashtopStreamer in recipe map
**load_recipe time: 0.007558957993751392
Processing SplashtopStreamer.munki.recipe...
WARNING: SplashtopStreamer.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLDownloader
URLDownloader: Item at URL is unchanged.
URLDownloader: Using existing /Users/paul.cossey/Library/AutoPkg/Cache/com.github.peetinc.munki.SplashtopStreamer/downloads/SplashtopStreamer.dmg
EndOfCheckPhase
CodeSignatureVerifier
CodeSignatureVerifier: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.peetinc.munki.SplashtopStreamer/downloads/SplashtopStreamer.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "Splashtop Streamer.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-09-13 12:22:41 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: Splashtop Inc. (CPQQ3AW49Y)
CodeSignatureVerifier:        Expires: 2029-04-10 06:16:02 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            28 A9 99 C7 76 29 41 3E 63 A1 5F 89 06 47 3B 96 1C 87 EF 18 AA 5D 
CodeSignatureVerifier:            06 FA F2 01 6C DD 68 8E 39 5C
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2031-09-17 00:00:00 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            F1 6C D3 C5 4C 7F 83 CE A4 BF 1A 3E 6A 08 19 C8 AA A8 E4 A1 52 8F 
CodeSignatureVerifier:            D1 44 71 5F 35 06 43 D2 DF 3A
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C 
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier: 
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
FlatPkgUnpacker
FlatPkgUnpacker: Mounted disk image /Users/paul.cossey/Library/AutoPkg/Cache/com.github.peetinc.munki.SplashtopStreamer/downloads/SplashtopStreamer.dmg
FlatPkgUnpacker: Unpacked /private/tmp/dmg.2AQPdP/Splashtop Streamer.pkg to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.peetinc.munki.SplashtopStreamer/unpack
PkgPayloadUnpacker
PkgPayloadUnpacker: Unpacked /Users/paul.cossey/Library/AutoPkg/Cache/com.github.peetinc.munki.SplashtopStreamer/unpack/Splashtop_Streamer-installer.pkg/Payload to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.peetinc.munki.SplashtopStreamer/Applications
Versioner
Versioner: Found version 3.7.2.0 in file /Users/paul.cossey/Library/AutoPkg/Cache/com.github.peetinc.munki.SplashtopStreamer/Applications/Splashtop Streamer.app/Contents/Info.plist
MunkiInstallsItemsCreator
MunkiInstallsItemsCreator: Created installs item for /Applications/Splashtop Streamer.app
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'installs': [{'CFBundleIdentifier': 'com.splashtop.Splashtop-Streamer', 'CFBundleName': 'Splashtop Streamer', 'CFBundleShortVersionString': '3.7.2.0', 'CFBundleVersion': '3.7.2.0', 'minosversion': '10.10', 'path': '/Applications/Splashtop Streamer.app', 'type': 'application', 'version_comparison_key': 'CFBundleShortVersionString'}]} into pkginfo
PlistReader
PlistReader: Reading: /Users/paul.cossey/Library/AutoPkg/Cache/com.github.peetinc.munki.SplashtopStreamer/Applications/Splashtop Streamer.app/Contents/Info.plist
PlistReader: Assigning value of '10.10' to output variable 'min_os_ver'
MunkiPkginfoMerger
MunkiPkginfoMerger: Merged {'minimum_os_version': '10.10'} into pkginfo
MunkiImporter
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Splashtop/SplashtopStreamer-3.7.2.0.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Splashtop/SplashtopStreamer-3.7.2.0.dmg
Receipt written to /Users/paul.cossey/Library/AutoPkg/Cache/com.github.peetinc.munki.SplashtopStreamer/receipts/SplashtopStreamer.munki-receipt-20240920-085424.plist

The following new items were imported into Munki:
    Name               Version  Catalogs  Pkginfo Path                                    Pkg Repo Path                                 Icon Repo Path  
    ----               -------  --------  ------------                                    -------------                                 --------------  
    SplashtopStreamer  3.7.2.0  testing   apps/Splashtop/SplashtopStreamer-3.7.2.0.plist  apps/Splashtop/SplashtopStreamer-3.7.2.0.dmg
```