### PR TITLE
Remove . in filepath that was preventing verification

### DIFF
--- a/SplashtopStreamer/SplashtopStreamer.download.recipe
+++ b/SplashtopStreamer/SplashtopStreamer.download.recipe
@@ -42,7 +42,7 @@
 					<string>Apple Root CA</string>
 				</array>
 				<key>input_path</key>
-				<string>%pathname%/.Splashtop Streamer.pkg</string>
+				<string>%pathname%/Splashtop Streamer.pkg</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
@@ -53,7 +53,7 @@
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/unpack</string>
 				<key>flat_pkg_path</key>
-				<string>%pathname%/.Splashtop Streamer.pkg</string>
+				<string>%pathname%/Splashtop Streamer.pkg</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>


### PR DESCRIPTION
Was getting 
Error processing path '/private/tmp/dmg.xIJ5hu/.Splashtop Streamer.pkg' with glob.  Failed.