### PR TITLE
Updated recipe for Privileges 2

### DIFF
--- a/Privileges/Privileges.munki.recipe
+++ b/Privileges/Privileges.munki.recipe
@@ -8,7 +8,7 @@
     <string>com.github.peetinc.munki.privileges</string>
     <key>Input</key>
     <dict>
-    	<key>DERIVE_MIN_OS</key>
+        <key>DERIVE_MIN_OS</key>
         <string>YES</string>
         <key>DESCRIPTION</key>
         <string>Privileges.app for macOS is designed to allow users to work as a standard user for day-to-day use, by providing a quick and easy way to get administrator rights when needed. When you do need admin rights, you can get them by clicking on the Privileges icon in your Dock.</string>
@@ -67,7 +67,7 @@ pkgutil --forget com.sap.privileges /</string>
             <string>MunkiInstallsItemsCreator</string>
             <key>Arguments</key>
             <dict>
-            	<key>derive_minimum_os_version</key>
+                <key>derive_minimum_os_version</key>
                 <string>%DERIVE_MIN_OS%</string>
                 <key>faux_root</key>
                 <string>%RECIPE_CACHE_DIR%/%NAME%/</string>

--- a/Privileges/Privileges.munki.recipe
+++ b/Privileges/Privileges.munki.recipe
@@ -49,15 +49,49 @@
             <key>uninstall_script</key>
             <string>#!/bin/bash
 
-if [[ -f "/Library/LaunchDaemons/corp.sap.privileges.helper.plist" ]]; then
-    launchctl unload "/Library/LaunchDaemons/corp.sap.privileges.helper.plist" &gt;&gt; /dev/null 2&gt;&amp;1 
-    rm -rf "/Library/LaunchDaemons/corp.sap.privileges.helper.plist"
-fi
+# Adapted from pre-install script inside Privileges v2 pkg installer
 
-rm -rf "/Applications/Privileges.app"
-rm -rf "/Library/PrivilegedHelperTools/corp.sap.privileges.helper"
+# Current console user information
+current_user=$(/bin/ls -l /dev/console | /usr/bin/awk '{ print $3 }')
+current_user_uid=$(/usr/bin/id -u "${current_user}")
+current_user_home=$(/usr/bin/dscl . read "/Users/${current_user}" NFSHomeDirectory | /usr/bin/cut -d' ' -f2)
 
-pkgutil --forget com.sap.privileges /</string>
+# unload the agent plist
+/bin/launchctl bootout gui/$(/usr/bin/id -u "$currentUser") /Library/LaunchAgents/corp.sap.privileges.agent.plist
+/bin/sleep 2
+/usr/bin/sudo -u "$currentUser" /usr/bin/killall "Privileges" "PrivilegesAgent" "PrivilegesCLI"
+
+# unload the old helper
+/bin/launchctl bootout system /Library/LaunchDaemons/corp.sap.privileges.helper.plist
+
+# unload the daemon plist
+/bin/launchctl bootout system /Library/LaunchDaemons/corp.sap.privileges.daemon.plist
+
+# just for sure ...
+/bin/sleep 2
+/usr/bin/killall "corp.sap.privileges.helper" "PrivilegesDaemon"
+
+# remove old stuff
+/bin/rm -rf "/Library/LaunchDaemons/corp.sap.privileges.helper.plist"
+/bin/rm -rf "/Library/LaunchAgents/corp.sap.privileges.plist"
+/bin/rm -rf "/Library/PrivilegedHelperTools/corp.sap.privileges.helper"
+/bin/rm -rf "/Applications/Privileges.app"
+	
+# Remove v2 files
+# Ref: https://github.com/SAP/macOS-enterprise-privileges/wiki/Uninstallation
+/bin/rm -rf "/Library/LaunchAgents/corp.sap.privileges.agent.plist"
+/bin/rm -rf "/Library/LaunchDaemons/corp.sap.privileges.daemon.plist"
+/bin/rm -rf "/Library/Preferences/corp.sap.PrivilegesDaemon.plist"
+/bin/rm -rf "/Library/Scripts/VoiceOver/Privileges Time Left.scpt"
+/bin/rm -rf "/private/etc/paths.d/PrivilegesCLI"
+/bin/rm -rf "${current_user_home}/Library/Containers/corp.sap.privileges."*
+/bin/rm -rf "${current_user_home}/Library/Application Scripts/corp.sap.privileges"*
+/bin/rm -rf "${current_user_home}/Library/Group Containers/7R5ZEU67FQ.corp.sap.privileges"
+/bin/rm -rf "${current_user_home}/Library/Preferences/corp.sap.privileges"*
+
+pkgutil --forget com.sap.privileges /
+
+exit 0</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>

--- a/Privileges/Privileges.munki.recipe
+++ b/Privileges/Privileges.munki.recipe
@@ -95,9 +95,35 @@ exit 0</string>
         </dict>
     </dict>
     <key>ParentRecipe</key>
-    <string>com.github.rtrouton.pkg.privileges</string>
+    <string>com.github.rtrouton.download.privileges</string>
     <key>Process</key>
     <array>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/unpack</string>
+                <key>flat_pkg_path</key>
+                <string>%pathname%</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>FlatPkgUnpacker</string>
+        </dict>
+        <dict>
+            <key>Arguments</key>
+            <dict>
+                <key>destination_path</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/payload</string>
+                <key>pkg_payload_path</key>
+                <string>%RECIPE_CACHE_DIR%/downloads/unpack/Privileges.pkg/Payload</string>
+                <key>purge_destination</key>
+                <true/>
+            </dict>
+            <key>Processor</key>
+            <string>PkgPayloadUnpacker</string>
+        </dict>
         <dict>
             <key>Processor</key>
             <string>MunkiInstallsItemsCreator</string>
@@ -106,7 +132,7 @@ exit 0</string>
                 <key>derive_minimum_os_version</key>
                 <string>%DERIVE_MIN_OS%</string>
                 <key>faux_root</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/payload</string>
                 <key>installs_item_paths</key>
                 <array>
                     <string>/Applications/Privileges.app</string>
@@ -123,7 +149,7 @@ exit 0</string>
             <key>Arguments</key>
             <dict>
                 <key>info_path</key>
-                <string>%RECIPE_CACHE_DIR%/%NAME%/Applications/Privileges.app/Contents/Info.plist</string>
+                <string>%RECIPE_CACHE_DIR%/downloads/payload/Applications/Privileges.app/Contents/Info.plist</string>
             </dict>
         </dict>
         <dict>
@@ -144,7 +170,7 @@ exit 0</string>
             <key>Arguments</key>
             <dict>
                 <key>pkg_path</key>
-                <string>%pkg_path%</string>
+                <string>%pathname%</string>
                 <key>repo_subdirectory</key>
                 <string>%MUNKI_REPO_SUBDIR%</string>
             </dict>
@@ -156,7 +182,8 @@ exit 0</string>
             <dict>
                 <key>path_list</key>
                 <array>
-                    <string>%RECIPE_CACHE_DIR%/%NAME%/</string>                    
+                    <string>%RECIPE_CACHE_DIR%/downloads/unpack</string>
+                    <string>%RECIPE_CACHE_DIR%/downloads/payload</string>
                 </array>
             </dict>
         </dict>

--- a/Privileges/Privileges.munki.recipe
+++ b/Privileges/Privileges.munki.recipe
@@ -24,6 +24,8 @@
         <string>Privileges</string>
         <key>pkginfo</key>
         <dict>
+            <key>blocking_applications</key>
+            <array/>
             <key>catalogs</key>
             <array>
                 <string>testing</string>


### PR DESCRIPTION
This recipe has been updated to use `com.github.rtrouton.download.privileges` as the parent (rather than pkg recipe) as the download from Github is now a pkg rather than a zip.

I've had to change the recipe a bit to include unpacking processors to retrieve the application and pass to `MunkiInstallsItemsCreator` correctly. The rest of the general recipe structure has stayed much the same.

The other significant change that I have implemented in this PR is to update the uninstall script. I have used the preinstall script provided inside the new Privileges installer pkg itself and then add a few of the additional paths to be removed are taken from the [Uninstallation Wiki page](https://github.com/SAP/macOS-enterprise-privileges/wiki/Uninstallation). I should note that this uninstall script only deletes user files for the currently logged in user and does not exhaustively go through and delete for all users on the computer.

I have tested this in my environment with both an upgrade from Privileges 1.5.4 to 2.0.0 and a fresh install of 2.0.0 via Munki. I have also tested the Uninstall of 2.0.0 via Munki.