### PR TITLE
Deprecate VipRiser recipes

### DIFF
--- a/OndrejFlorian/VipRiser.download.recipe
+++ b/OndrejFlorian/VipRiser.download.recipe
@@ -20,6 +20,15 @@
 		<key>Process</key>
 		<array>
 			<dict>
+				<key>Processor</key>
+				<string>DeprecationWarning</string>
+				<key>Arguments</key>
+				<dict>
+					<key>warning_message</key>
+					<string>VipRiser is no longer available for download. This recipe is deprecated and will be removed in the future.</string>
+				</dict>
+			</dict>
+			<dict>
 				<key>Arguments</key>
 				<dict>
 					<key>appcast_url</key>


### PR DESCRIPTION
This PR deprecates the VipRiser reipces, since the appcast is no longer online and the app doesn't appear to be available for download any more.
