### PR TITLE
Deprecate NoMAD Login AD recipes

### DIFF
--- a/NoMADLoginAD/NoMADLoginAD.download.recipe
+++ b/NoMADLoginAD/NoMADLoginAD.download.recipe
@@ -19,9 +19,18 @@ This recipe differs from the ones in bochoven-recipes in the following ways:
             <string>https://files.nomad.menu/NoMAD-Login-AD.pkg</string>
         </dict>
         <key>MinimumVersion</key>
-        <string>1.0</string>
+        <string>1.1</string>
         <key>Process</key>
         <array>
+            <dict>
+                <key>Processor</key>
+                <string>DeprecationWarning</string>
+                <key>Arguments</key>
+                <dict>
+                    <key>warning_message</key>
+                    <string>NoMAD Login AD has been archived and will receive no further updates (details: https://www.jamf.com/blog/jamf-to-archive-nomad-open-source-projects/). This recipe is deprecated and will be removed in the future.</string>
+                </dict>
+            </dict>
             <dict>
                 <key>Processor</key>
                 <string>URLDownloader</string>


### PR DESCRIPTION
This PR deprecates the NoMAD Login AD recipes, since the software will be receiving no futher updates ([details](https://www.jamf.com/blog/jamf-to-archive-nomad-open-source-projects/)).
