### PR TITLE
Deprecate Rectangle recipes

### DIFF
--- a/Rectangle/Rectangle.download.recipe
+++ b/Rectangle/Rectangle.download.recipe
@@ -20,9 +20,18 @@ https://github.com/rxhanson/Rectangle/issues/73#issuecomment-581141111
 			<string>Rectangle</string>		
 		</dict>
 		<key>MinimumVersion</key>
-		<string>1.0.0</string>
+		<string>1.1</string>
 		<key>Process</key>
 		<array>
+			<dict>
+				<key>Processor</key>
+				<string>DeprecationWarning</string>
+				<key>Arguments</key>
+				<dict>
+					<key>warning_message</key>
+					<string>Consider switching to the Rectangle recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+				</dict>
+			</dict>
 			<dict>
 				<key>Arguments</key>
 				<dict>


### PR DESCRIPTION
The Rectangle recipes in this repo are redundant with the ones offered by the dataJAR-recipes repo. This PR deprecates these Rectangle recipes and points users to the alternatives in dataJAR-recipes.
