### PR TITLE
20251122-fix-endofcheckphase

### DIFF
--- a/BaseCamp/GarminBaseCamp.download.recipe
+++ b/BaseCamp/GarminBaseCamp.download.recipe
@@ -43,7 +43,10 @@
 			<key>Processor</key>
 			<string>URLDownloader</string>
 		</dict>
-		
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>
@@ -69,11 +72,6 @@
 			</dict>
 			<key>Processor</key>
 			<string>PkgRootCreator</string>
-		</dict>
-
-		<dict>
-			<key>Processor</key>
-			<string>EndOfCheckPhase</string>
 		</dict>
 	</array>
 </dict>


### PR DESCRIPTION
In order to use AutoPkg with the `--check` argument, download recipes must include an `EndOfCheckPhase` processor. This processor indicates where to stop processing when checking for new downloaded files. The proper placement of the processor is directly after the last `URLDownloader` or `URLDownloaderPython` processor to eliminate unnecessary processing (such as a code signature verification of an unchanged file).

This pull request adds the `EndOfCheckPhase` processor if is is missing and moves it to the correct location if it already exists.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0.