### PR TITLE
Enable arch-specific version download

### DIFF
--- a/Cursor/Cursor.download.recipe
+++ b/Cursor/Cursor.download.recipe
@@ -3,11 +3,14 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest Universal version of Cursor.</string>
+	<string>Downloads the latest version of Cursor.
+For the Apple Silicon-only version use "arm64" in the DOWNLOAD_ARCH variable, "x64" for Intel.</string>
 	<key>Identifier</key>
 	<string>com.github.peetinc.download.Cursor</string>
 	<key>Input</key>
 	<dict>
+		<key>DOWNLOAD_ARCH</key>
+		<string>universal</string>
 		<key>NAME</key>
 		<string>Cursor</string>
 	</dict>
@@ -21,7 +24,7 @@
 				<key>re_pattern</key>
 				<string>"downloadUrl":"(https[^"]+\.dmg)"</string>
 				<key>url</key>
-				<string>https://www.cursor.com/api/download?platform=darwin-universal&amp;releaseTrack=stable</string>
+				<string>https://www.cursor.com/api/download?platform=darwin-%DOWNLOAD_ARCH%&amp;releaseTrack=stable</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>

--- a/Cursor/Cursor.munki.recipe
+++ b/Cursor/Cursor.munki.recipe
@@ -8,6 +8,8 @@
 	<string>com.github.peetinc.munki.Cursor</string>
 	<key>Input</key>
 	<dict>
+		<key>DOWNLOAD_ARCH</key>
+		<string>universal</string>
 		<key>MUNKI_CATEGORY</key>
 		<string>Developer</string>
 		<key>MUNKI_REPO_SUBDIR</key>

--- a/Cursor/Cursor.pkg.recipe
+++ b/Cursor/Cursor.pkg.recipe
@@ -10,6 +10,8 @@
 	<string>com.github.peetinc.pkg.Cursor</string>
 	<key>Input</key>
 	<dict>
+		<key>DOWNLOAD_ARCH</key>
+		<string>universal</string>
 		<key>NAME</key>
 		<string>Cursor</string>
 	</dict>


### PR DESCRIPTION
Added input, w/comment about usage at download flavor, and entries to the downstream/child recipes