### PR TITLE
fix: update Cursor download API URL

### DIFF
--- a/Cursor/Cursor.download.recipe
+++ b/Cursor/Cursor.download.recipe
@@ -41,7 +41,7 @@ Possible values for RELEASETRACK include:
 				<key>re_pattern</key>
 				<string>"downloadUrl":"(https[^"]+\.dmg)"</string>
 				<key>url</key>
-				<string>https://www.cursor.com/api/download?platform=%PLATFORM%&amp;releaseTrack=%RELEASETRACK%</string>
+				<string>https://api2.cursor.sh/updates/api/download/%RELEASETRACK%/%PLATFORM%/cursor</string>
 			</dict>
 			<key>Processor</key>
 			<string>URLTextSearcher</string>


### PR DESCRIPTION
The cursor.com/api/download endpoint now returns 404. This updates the download URL to the new api2.cursor.sh/updates/api/download/{releaseTrack}/{platform}/cursor endpoint, which returns the same JSON structure (including the downloadUrl field used by URLTextSearcher).